### PR TITLE
fix(NUM-1712): Hides the terms modal if not used

### DIFF
--- a/login/resources/css/login.css
+++ b/login/resources/css/login.css
@@ -330,6 +330,10 @@ a#kc-current-locale-link:hover {
   border-radius: 2px;
 }
 
+.modal.fade {
+  display: none;
+}
+
 .modal-body {
   padding: 15px 23px;
 }


### PR DESCRIPTION
This PR fixes the issue that some fields in the registration process couldn't be selected in safari due to the terms modal being in front of them.